### PR TITLE
Allow newer pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 requirements = [
-    'pycryptodome==3.6.6'
+    'pycryptodome>=3.6.6'
 ]
 
 setup(


### PR DESCRIPTION
Hi!

This requirement is blocking us from upgrading the pycryptodome. So how about allowing a newer version?

Is there anything else I should do? I noticed the previously made pycryptodome also upgraded the version of this project.